### PR TITLE
Added package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "superagent-legacyIESupport",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trevorreeves/superagent-legacyIESupport"
+  },
+  "main": "superagent-legacyIESupport.js"
+}


### PR DESCRIPTION
Apparently npm needs a `package.json` to specify this git repo as a dependency. So, here you go.
