### PR TITLE
Forcing browser check first to ensure parseUrl is not called on the server side

### DIFF
--- a/superagent-legacyIESupport.js
+++ b/superagent-legacyIESupport.js
@@ -102,12 +102,14 @@
      * Overrides .end() to use XDomainRequest object when necessary (making a cross domain request on IE 8 & 9.
      */
 
-    // if request to other domain, and we're on a relevant browser
-    var parsedUrl = parseUrl(superagent.url);
-    if (parsedUrl.hostname != window.location.hostname &&
-        typeof XDomainRequest !== "undefined") { // IE 8 & 9
-        // (note another XDomainRequest restriction - calls must always be to the same protocol as the current page.)
-        superagent.end = xDomainRequestEnd;
+    // if we're on a relevant browser
+    if (typeof XDomainRequest !== "undefined") { // IE 8 & 9
+      // if request to other domain
+      var parsedUrl = parseUrl(superagent.url);
+      if (parsedUrl.hostname != window.location.hostname) { // IE 8 & 9
+          // (note another XDomainRequest restriction - calls must always be to the same protocol as the current page.)
+          superagent.end = xDomainRequestEnd;
+      }
     }
 
 };


### PR DESCRIPTION
Our library that uses superagent is used both on the client side and the server side.  We noticed that the introduction of superagent-legacyIESupport broke our server side requests.  This commit fixes the issue.

The old implementation would call the `parseUrl` function before checking for a relevant browser.  Because `parseUrl`'s implementation expects `document.createElement` to exist, server issued requests would fail.

The new implementation forces us to check for a relevant browser first.  This makes sure that parseUrl is only called if the code is being run in IE8 or IE9.
